### PR TITLE
Correcting a really tiny typo in the include directives

### DIFF
--- a/src/GetHostAPIs.cc
+++ b/src/GetHostAPIs.cc
@@ -14,7 +14,7 @@
 */
 
 #include <napi.h>
-#include "GetHostApis.h"
+#include "GetHostAPIs.h"
 #include <portaudio.h>
 
 namespace streampunk {

--- a/src/naudiodon.cc
+++ b/src/naudiodon.cc
@@ -15,7 +15,7 @@
 
 #include <napi.h>
 #include "GetDevices.h"
-#include "GetHostApis.h"
+#include "GetHostAPIs.h"
 #include "AudioIO.h"
 
 Napi::Object InitAll(Napi::Env env, Napi::Object exports) {


### PR DESCRIPTION
Hi,

First, I'm sorry for creating a pull request for such a tiny thing. I actually found two typos preventing the module from building with node-gyp on my particular configuration. I thought it might be useful for others too.

Thanks for the great work so far ! 