### PR TITLE
Make the built Mac bindings portable

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -26,16 +26,16 @@
                 '-std=c++11',
                 '-stdlib=libc++',
                 '-fexceptions'
-              ],
-              'OTHER_LDFLAGS': [
-                "-Wl,-rpath,<@(module_root_dir)/build/Release"
               ]
             },
             "link_settings": {
               "libraries": [
-                "<@(module_root_dir)/build/Release/libportaudio.dylib"
+                "-Wl,-rpath,@loader_path"
               ]
             },
+            "libraries": [
+              "libportaudio.dylib"
+            ],
             "copies": [
               {
                 "destination": "build/Release/",


### PR DESCRIPTION
On mac, when the bindings is compiled, the linking is absolute to the machine that built the bindings which makes it impossible to redistribute. This change makes the linking of the library relative and expects the binding and binary to be in the same folder for easier distribution