### PR TITLE
Add #include <cstring> to fix Linux build

### DIFF
--- a/src/Memory.h
+++ b/src/Memory.h
@@ -17,6 +17,7 @@
 #define MEMORY_H
 
 #include <memory>
+#include <cstring>
 
 namespace streampunk {
 


### PR DESCRIPTION
This include is needed on Linux for `memcpy`